### PR TITLE
Fixed URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: minio/mc
     entrypoint: |
       sh -c 'sh -s << EOF
-      mc config host add tmp minio:9000 EXAMPLEKEY EXAMPLESECRET
+      mc config host add tmp http://minio:9000 EXAMPLEKEY EXAMPLESECRET
       mc mb tmp/thanos
       mc config host rm tmp
       sleep 10000000


### PR DESCRIPTION
Hi.. I have to fix the url and add the `scheme`. Otherwise the MinIO client was failing with following error

```
mc: <ERROR> Invalid URL. URL `minio:9000` for MinIO Client should be of the form scheme://host[:port]/ without resource component.
```